### PR TITLE
feat(seeds): add database seeding for teachers, subjects, and loads

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ DB_URI=your_mongodb_connection_string
 DB_NAME=teaching_load
 ```
 
+---
+
 ## 🛠️ Scripts
 
 ```bash
@@ -54,6 +56,8 @@ npm start
 npm run seed
 
 ```
+
+---
 
 ## 🌐 API Endpoints
 
@@ -108,42 +112,60 @@ http://localhost:5000/api/docs
 
 ```
 
+---
+
 ## 🧩 Project Structure
 
 ```bash
 
 backend/
+│── docs/
+│   ├── seeds/
+│   │   ├── loads.json                  # Database seeding mechanism
+│   │   ├── subjects.json
+│   │   └── teachers.json
 │── src/
 │   ├── config/                         # Database configuration
 │   │   └── db.ts
 │   ├── controllers/                    # Route controllers
-│   │   ├── teacher.controller.ts
+│   │   ├── load.controller.ts
 │   │   ├── subject.controller.ts
-│   │   └── load.controller.ts
-│   ├── models/                         # Mongoose models
-│   │   ├── teacher.model.ts
-│   │   ├── subject.model.ts
-│   │   └── load.model.ts
-│   ├── routes/                         # Express routes
-│   │   ├── health.route.ts
-│   │   ├── teacher.route.ts
-│   │   ├── subject.route.ts
-│   │   └── load.route.ts
-│   ├── middlewares/                    # Express middlewares (errors, validation, logging)
+│   │   └── teacher.controller.ts
 │   ├── docs/                           # Swagger & Postman docs
-│   │   ├── swagger.ts
 │   │   └── postman/
 │   │       ├── TeachingLoad.postman_collection.json
 │   │       └── TeachingLoad.postman_environment.json
+│   │   └── swagger.ts
+│   ├── middlewares/                    # Express middlewares
+│   │   ├── errorHandler.ts             # Errors
+│   │   ├── logger.ts                   # Logging
+│   │   └── validateRequest.ts          # Validation
+│   ├── models/                         # Mongoose models
+│   │   ├── load.model.ts
+│   │   ├── subject.model.ts
+│   │   └── teacher.model.ts
+│   ├── routes/                         # Express routes
+│   │   ├── health.route.ts
+│   │   ├── load.route.ts
+│   │   ├── subject.route.ts
+│   │   └── teacher.route.ts
+│   ├── scripts/                        # Seed
+│   │   └── seed.ts
 │   ├── types/                          # Custom TypeScript interfaces
 │   │   ├── entities.ts
 │   │   └── env.d.ts
+│   ├── validations/                    # Validation
+│   │   ├── load.validation.ts
+│   │   ├── subject.validation.ts
+│   │   └── teacher.validation.ts
 │   └── server.ts                       # App entry point
 │── .env                                # Environment variables
-│── tsconfig.json                       #  TypeScript config
+│── tsconfig.json                       # TypeScript config
 │── package.json
 
 ```
+
+---
 
 ## ✅ Acceptance Criteria
 
@@ -169,14 +191,28 @@ To test the API with Postman:
 4. Set the environment to **TeachingLoad Local**.
 5. Run CRUD requests for Teachers, Subjects, and Loads.
 
+---
+
+## 🌱 Database Seeding
+
+This project includes a seeding script to quickly populate MongoDB with initial data for testing.
+
+### Run the seed script:
+
+```bash
+npm run seed
+```
+
+---
+
 ## 📌 Related
 
 This backend is part of the **Teaching Load API** project.
+
+---
 
 #### Future improvements:
 
 - Authentication & Authorization (JWT).
 
-- Middleware for validation and error handling.
-
-- Database seeders for test data.
+---

--- a/docs/seeds/loads.json
+++ b/docs/seeds/loads.json
@@ -1,0 +1,14 @@
+[
+  {
+    "teacher": "replace_with_teacher_id",
+    "subject": "replace_with_subject_id",
+    "group": "CS-21",
+    "type": "lecture"
+  },
+  {
+    "teacher": "replace_with_teacher_id",
+    "subject": "replace_with_subject_id",
+    "group": "MATH-11",
+    "type": "practice"
+  }
+]

--- a/docs/seeds/subjects.json
+++ b/docs/seeds/subjects.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "Computer Science",
+    "hours": 64
+  },
+  {
+    "name": "Mathematics",
+    "hours": 48
+  }
+]

--- a/docs/seeds/teachers.json
+++ b/docs/seeds/teachers.json
@@ -1,0 +1,18 @@
+[
+  {
+    "firstName": "Oleh",
+    "lastName": "Ivanenko",
+    "middleName": "Petrovych",
+    "degree": "PhD",
+    "position": "Associate Professor",
+    "experience": 8
+  },
+  {
+    "firstName": "Iryna",
+    "lastName": "Shevchenko",
+    "middleName": "Mykolaivna",
+    "degree": "Doctor of Science",
+    "position": "Professor",
+    "experience": 15
+  }
+]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "build": "tsc",
-    "start": "node dist/server.js"
+    "start": "node dist/server.js",
+    "seed": "tsx src/scripts/seed.ts"
   },
   "repository": {
     "type": "git",

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -1,0 +1,60 @@
+import mongoose from "mongoose";
+import * as dotenv from "dotenv";
+import { fileURLToPath } from "url";
+import { Teacher } from "../models/teacher.model.js";
+import { Subject } from "../models/subject.model.js";
+import { Load } from "../models/load.model.js";
+import fs from "fs";
+import path from "path";
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function seedData() {
+  try {
+    await mongoose.connect(process.env.DB_URI as string, {
+      dbName: process.env.DB_NAME,
+    });
+    console.log("Connected to MongoDB");
+
+    // Clear collections
+    await Teacher.deleteMany({});
+    await Subject.deleteMany({});
+    await Load.deleteMany({});
+    console.log("Cleared existing data");
+
+    // Load JSON data
+    const teachers = JSON.parse(
+      fs.readFileSync(path.join(__dirname, "../../docs/seeds/teachers.json"), "utf-8")
+    );
+    const subjects = JSON.parse(
+      fs.readFileSync(path.join(__dirname, "../../docs/seeds/subjects.json"), "utf-8")
+    );
+    const loads = JSON.parse(
+      fs.readFileSync(path.join(__dirname, "../../docs/seeds/loads.json"), "utf-8")
+    );
+
+    // Insert teachers & subjects
+    const createdTeachers = await Teacher.insertMany(teachers);
+    const createdSubjects = await Subject.insertMany(subjects);
+
+    // Fix loads with real IDs
+    const fixedLoads = loads.map((load: any, index: number) => ({
+      ...load,
+      teacher: createdTeachers[index % createdTeachers.length]._id,
+      subject: createdSubjects[index % createdSubjects.length]._id,
+    }));
+
+    await Load.insertMany(fixedLoads);
+    
+    console.log("Seeding completed successfully");
+    process.exit(0);
+  } catch (err) {
+    console.error("Seeding error:", err);
+    process.exit(1);
+  }
+}
+
+seedData();


### PR DESCRIPTION
- Added seed **JSON** files: `docs/seeds/teachers.json`, `subjects.json`, `loads.json`
- Implemented `src/scripts/seed.ts` to populate **MongoDB** with initial data
- Linked loads to real teacher and subject IDs during seeding
- Updated package.json with `"npm run seed" `script
- Updated **README** with instructions for running seed script

Closes #15 