### PR TITLE
feat(loads): add year field & support historical data

### DIFF
--- a/docs/seeds/loads.json
+++ b/docs/seeds/loads.json
@@ -1,14 +1,72 @@
 [
   {
-    "teacher": "replace_with_teacher_id",
-    "subject": "replace_with_subject_id",
+    "teacher": "replace_with_teacher_id_1",
+    "subject": "replace_with_subject_id_1",
     "group": "CS-21",
-    "type": "lecture"
+    "type": "lecture",
+    "year": 2023
   },
   {
-    "teacher": "replace_with_teacher_id",
-    "subject": "replace_with_subject_id",
+    "teacher": "replace_with_teacher_id_2",
+    "subject": "replace_with_subject_id_2",
+    "group": "CS-21",
+    "type": "practice",
+    "year": 2023
+  },
+  {
+    "teacher": "replace_with_teacher_id_3",
+    "subject": "replace_with_subject_id_1",
+    "group": "CS-22",
+    "type": "lecture",
+    "year": 2024
+  },
+  {
+    "teacher": "replace_with_teacher_id_1",
+    "subject": "replace_with_subject_id_3",
     "group": "MATH-11",
-    "type": "practice"
+    "type": "practice",
+    "year": 2024
+  },
+  {
+    "teacher": "replace_with_teacher_id_4",
+    "subject": "replace_with_subject_id_2",
+    "group": "MATH-12",
+    "type": "lecture",
+    "year": 2025
+  },
+  {
+    "teacher": "replace_with_teacher_id_5",
+    "subject": "replace_with_subject_id_3",
+    "group": "PHYS-10",
+    "type": "lecture",
+    "year": 2025
+  },
+  {
+    "teacher": "replace_with_teacher_id_2",
+    "subject": "replace_with_subject_id_4",
+    "group": "PHYS-10",
+    "type": "practice",
+    "year": 2025
+  },
+  {
+    "teacher": "replace_with_teacher_id_3",
+    "subject": "replace_with_subject_id_1",
+    "group": "CS-23",
+    "type": "lecture",
+    "year": 2025
+  },
+  {
+    "teacher": "replace_with_teacher_id_4",
+    "subject": "replace_with_subject_id_2",
+    "group": "CS-24",
+    "type": "practice",
+    "year": 2025
+  },
+  {
+    "teacher": "replace_with_teacher_id_5",
+    "subject": "replace_with_subject_id_3",
+    "group": "MATH-13",
+    "type": "lecture",
+    "year": 2025
   }
 ]

--- a/docs/seeds/subjects.json
+++ b/docs/seeds/subjects.json
@@ -1,10 +1,22 @@
 [
-  {
-    "name": "Computer Science",
-    "hours": 64
-  },
-  {
-    "name": "Mathematics",
-    "hours": 48
-  }
+  { "name": "Computer Science",
+    "hours": 64 },
+  { "name": "Mathematics",
+    "hours": 48 },
+  { "name": "Physics",
+    "hours": 60 },
+  { "name": "Algorithms",
+    "hours": 56 },
+  { "name": "Databases",
+    "hours": 50 },
+  { "name": "Operating Systems",
+    "hours": 54 },
+  { "name": "Software Engineering",
+    "hours": 58 },
+  { "name": "Artificial Intelligence",
+    "hours": 70 },
+  { "name": "Statistics",
+    "hours": 46 },
+  { "name": "Data Structures",
+    "hours": 52 }
 ]

--- a/docs/seeds/teachers.json
+++ b/docs/seeds/teachers.json
@@ -1,18 +1,72 @@
 [
-  {
-    "firstName": "Oleh",
+  { "firstName": "Oleh",
     "lastName": "Ivanenko",
     "middleName": "Petrovych",
     "degree": "PhD",
     "position": "Associate Professor",
     "experience": 8
   },
-  {
-    "firstName": "Iryna",
+  { "firstName": "Iryna",
     "lastName": "Shevchenko",
     "middleName": "Mykolaivna",
     "degree": "Doctor of Science",
     "position": "Professor",
     "experience": 15
+  },
+  { "firstName": "Vita",
+    "lastName": "Koc",
+    "middleName": "Serhiivna",
+    "degree": "PhD",
+    "position": "Senior Lecturer",
+    "experience": 10
+  },
+  { "firstName": "Andriy",
+    "lastName": "Melnyk",
+    "middleName": "Ivanovych",
+    "degree": "PhD",
+    "position": "Associate Professor",
+    "experience": 6
+  },
+  { "firstName": "Olena",
+    "lastName": "Kravchenko",
+    "middleName": "Vasylivna",
+    "degree": "PhD",
+    "position": "Senior Lecturer",
+    "experience": 12
+  },
+  { "firstName": "Yurii",
+    "lastName": "Bondar",
+    "middleName": "Olehhovych",
+    "degree": "Doctor of Science",
+    "position": "Professor",
+    "experience": 20
+  },
+  { "firstName": "Svitlana",
+    "lastName": "Hrytsenko",
+    "middleName": "Volodymyrivna",
+    "degree": "PhD",
+    "position": "Lecturer",
+    "experience": 4
+  },
+  { "firstName": "Petro",
+    "lastName": "Tkachenko",
+    "middleName": "Stepanovych",
+    "degree": "PhD",
+    "position": "Associate Professor",
+    "experience": 7
+  },
+  { "firstName": "Nataliia",
+    "lastName": "Polishchuk",
+    "middleName": "Oleksandrivna",
+    "degree": "PhD",
+    "position": "Senior Lecturer",
+    "experience": 9
+  },
+  { "firstName": "Dmytro",
+    "lastName": "Horbach",
+    "middleName": "Anatoliiovych",
+    "degree": "PhD",
+    "position": "Lecturer",
+    "experience": 3
   }
 ]

--- a/src/controllers/load.controller.ts
+++ b/src/controllers/load.controller.ts
@@ -3,7 +3,14 @@ import {Load} from "../models/load.model.js";
 
 export const getAllLoads = async (req: Request, res: Response) => {
   try {
-    const loads = await Load.find().populate("teacher").populate("subject");
+    const {year} = req.query;
+
+    const filter: any = {};
+    if (year) {
+      filter.year = Number(year);
+    }
+
+    const loads = await Load.find(filter).populate("teacher").populate("subject");
     res.json(loads);
   } catch (error) {
     res.status(500).json({ message: "Server error" });
@@ -32,7 +39,7 @@ export const createLoad = async (req: Request, res: Response) => {
 
 export const updateLoad = async (req: Request, res: Response) => {
   try {
-    const load = await Load.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    const load = await Load.findByIdAndUpdate(req.params.id, req.body, { new: true, runValidators: true });
     if (!load) return res.status(404).json({ message: "Load not found" });
     res.json(load);
   } catch (error) {
@@ -40,11 +47,27 @@ export const updateLoad = async (req: Request, res: Response) => {
   }
 };
 
+export const patchLoad = async (req: Request, res: Response) => {
+  try {
+    const load = await Load.findByIdAndUpdate(
+      req.params.id,
+      { $set: req.body },
+      { new: true, runValidators: true }
+    );
+
+    if (!load) return res.status(404).json({ message: "Load not found" });
+
+    res.json(load);
+  } catch (error) {
+    res.status(400).json({ message: "Invalid patch data" });
+  }
+};
+
 export const deleteLoad = async (req: Request, res: Response) => {
   try {
     const load = await Load.findByIdAndDelete(req.params.id);
     if (!load) return res.status(404).json({ message: "Load not found" });
-    res.json({ message: "Load deleted" });
+    res.json({ message: "Load deleted  successfully" });
   } catch (error) {
     res.status(500).json({ message: "Server error" });
   }

--- a/src/models/load.model.ts
+++ b/src/models/load.model.ts
@@ -6,6 +6,7 @@ const loadSchema = new Schema<ILoad>({
   subject: { type: Types.ObjectId, ref: "Subject", required: true },
   group: { type: String, required: true },
   type: { type: String, enum: ["lecture", "practice"], required: true },
+  year: { type: Number, required: true, default: new Date().getFullYear() }
 });
 
 export const Load = model<ILoad>("Load", loadSchema);

--- a/src/routes/load.route.ts
+++ b/src/routes/load.route.ts
@@ -4,10 +4,11 @@ import {
   getLoadById,
   createLoad,
   updateLoad,
+  patchLoad,
   deleteLoad
 } from "../controllers/load.controller.js";
 import { validateRequest } from "../middlewares/validateRequest.js";
-import { loadValidationSchema } from "../validations/load.validation.js";
+import { loadValidationSchema, loadPatchValidationSchema } from "../validations/load.validation.js";
 import { authMiddleware } from "../middlewares/authMiddleware.js";
 
 const router = Router();
@@ -23,8 +24,15 @@ const router = Router();
  * @swagger
  * /api/loads:
  *   get:
- *     summary: Get all teaching loads
+ *     summary: Get all teaching loads (optionally filter by year)
  *     tags: [Loads]
+ *     parameters:
+ *       - in: query
+ *         name: year
+ *         schema:
+ *           type: integer
+ *         required: false
+ *         description: Filter loads by year
  *     responses:
  *       200:
  *         description: List of loads
@@ -69,6 +77,7 @@ router.get("/:id", authMiddleware, getLoadById);
  *               - subject
  *               - group
  *               - type
+ *               - year
  *             properties:
  *               teacher:
  *                 type: string
@@ -81,6 +90,9 @@ router.get("/:id", authMiddleware, getLoadById);
  *               type:
  *                 type: string
  *                 enum: [lecture, practice]
+ *               year:
+ *                 type: number
+ *                 description: Year of the load  
  *     responses:
  *       201:
  *         description: Load created
@@ -91,7 +103,7 @@ router.post("/", authMiddleware, validateRequest(loadValidationSchema), createLo
  * @swagger
  * /api/loads/{id}:
  *   put:
- *     summary: Update a teaching load by ID
+ *     summary: Full update a teaching load by ID
  *     tags: [Loads]
  *     parameters:
  *       - in: path
@@ -116,6 +128,8 @@ router.post("/", authMiddleware, validateRequest(loadValidationSchema), createLo
  *               type:
  *                 type: string
  *                 enum: [lecture, practice]
+ *               year:
+ *                 type: number
  *     responses:
  *       200:
  *         description: Load updated
@@ -123,6 +137,46 @@ router.post("/", authMiddleware, validateRequest(loadValidationSchema), createLo
  *         description: Load not found
  */
 router.put("/:id", authMiddleware, validateRequest(loadValidationSchema), updateLoad);
+
+/**
+ * @swagger
+ * /api/loads/{id}:
+ *   patch:
+ *     summary: Partial update of a teaching load by ID
+ *     tags: [Loads]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: Load ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               teacher:
+ *                 type: string
+ *               subject:
+ *                 type: string
+ *               group:
+ *                 type: string
+ *               type:
+ *                 type: string
+ *                 enum: [lecture, practice]
+ *               year:
+ *                 type: number
+ *     responses:
+ *       200:
+ *         description: Load patched
+ *       404:
+ *         description: Load not found
+ */
+router.patch("/:id", authMiddleware, validateRequest(loadPatchValidationSchema), patchLoad);
+
 
 /**
  * @swagger

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -1,3 +1,5 @@
+import { Types } from "mongoose";
+
 export interface ITeacher {
   firstName: string;
   lastName: string;
@@ -13,10 +15,11 @@ export interface ISubject {
 }
 
 export interface ILoad {
-  teacher: ITeacher;
-  subject: ISubject;
+  teacher: Types.ObjectId | ITeacher;
+  subject: Types.ObjectId | ISubject;
   group: string;
   type: "lecture" | "practice";
+  year: number;
 }
 
 export interface IUser {

--- a/src/validations/load.validation.ts
+++ b/src/validations/load.validation.ts
@@ -5,4 +5,16 @@ export const loadValidationSchema = Joi.object({
   subject: Joi.string().required(),
   group: Joi.string().required(),
   type: Joi.string().valid("lecture", "practice").required(),
+  year: Joi.number().integer().min(2000).max(new Date().getFullYear()).required()
 });
+
+export const loadPatchValidationSchema = Joi.object({
+  teacher: Joi.string(),
+  subject: Joi.string(),
+  group: Joi.string(),
+  type: Joi.string().valid("lecture", "practice"),
+  year: Joi.number()
+    .integer()
+    .min(2000)
+    .max(new Date().getFullYear()),
+}).min(1);


### PR DESCRIPTION
- Added year field to Load model and validation

- Implemented filtering by year in `GET /api/loads`

- Added `PATCH /api/loads/:id` for partial updates

- Updated **Swagger** documentation for year and `PATCH`
 
- Updated seed data with year field